### PR TITLE
VC generation for a simple language

### DIFF
--- a/naturalproofs/uct.py
+++ b/naturalproofs/uct.py
@@ -38,6 +38,9 @@ class UCTSort:
     def get_lattice_bottom_element(self):
         return self.lattice_bottom
 
+    def __repr__(self):
+        return self.name
+
 
 # Sorts supported in the UCT fragment
 # Foreground sort

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 z3-solver==4.8.9.0
 importlib_resources==3.3.0
 psutil==5.8.0
-
+pyparsing==3.0.7

--- a/vcgen/CombinatorLogic.py
+++ b/vcgen/CombinatorLogic.py
@@ -23,6 +23,7 @@ class CombinatorLogic:
     This class defines a combinatory logic on top of a term grammar given as input. The incoming term grammar is
     usually one defining a language of applications (variables and functions applied to variables).
     """
+
     def __init__(self, application_grammar):
         self.Application = application_grammar
 
@@ -112,8 +113,11 @@ class CombinatorLogic:
                 well_typed = arg2sort == sort_to_setsort[arg1sort]
             else:
                 # Comparisons other than equality/disequality cannot be made on Loc or Bool sort terms
-                well_typed = False if (
-                            binop not in {'==', '!='} and arg1sort in {fgsort, boolsort}) else arg1sort == arg2sort
+                if binop not in {'==', '!='} and arg1sort in {fgsort, boolsort}:
+                    well_typed = False
+                else:
+                    # Check that the arguments have the same sort
+                    well_typed = arg1sort == arg2sort
             if not well_typed:
                 raise BadType(
                     f'Cannot interpret {arg1} {binop} {arg2} between arguments of sorts {arg1sort} and {arg2sort}',

--- a/vcgen/CombinatorLogic.py
+++ b/vcgen/CombinatorLogic.py
@@ -1,0 +1,173 @@
+"""
+This module defines a class whose objects instantiate a formula parser given a grammar of atoms
+"""
+
+import pyparsing as pp
+
+import z3
+from z3 import And, Or, Not, Implies, If
+from z3 import IsSubset, SetUnion, SetIntersect, SetAdd
+
+from naturalproofs.uct import fgsort, fgsetsort, intsort, intsetsort, boolsort, get_uct_sort
+
+from vcgen.utils import sort_to_setsort, BadType, LParen, RParen
+
+"""
+TODO:
+1) If-Then-Else expressions for formulas (and possibly terms)
+"""
+
+
+class CombinatorLogic:
+    """
+    This class defines a combinatory logic on top of a term grammar given as input. The incoming term grammar is
+    usually one defining a language of applications (variables and functions applied to variables).
+    """
+    def __init__(self, application_grammar):
+        self.Application = application_grammar
+
+        # Nonterminal representing the formula and term parser elements to be instantiated
+        Formula = pp.Forward()
+        Term = pp.Forward()
+        self.Formula = Formula
+        self.Term = Term
+
+        # Grammar for terms
+        IntConstTerm = pp.common.signed_integer
+        SetIntConstTerm = pp.Literal("empSetInt")
+        SetLocConstTerm = pp.Literal("empSetLoc")
+        ConstTerm = SetIntConstTerm ^ SetLocConstTerm ^ IntConstTerm
+        # UnTermOp = "singleton"  # constructing a singleton set
+        BinTermOp = pp.one_of("+ - * & |")
+        # Parse action for TermAtom will be defined automatically defined once the action for each OR piece is defined
+        TermAtom = ConstTerm ^ self.Application
+        Term <<= TermAtom ^ (LParen + Term + BinTermOp + Term + RParen)
+
+        # Interpretation for terms
+        # A term is interpreted as a z3.ExprRef. The interpretation functions below return both the interpretation and the
+        # uct sort to be used when parsing formulas.
+        @IntConstTerm.set_parse_action
+        def interpret_int_const(string, loc, tokens):
+            return tokens[0], intsort
+
+        @SetLocConstTerm.set_parse_action
+        def interpret_empty_locset(string, loc, tokens):
+            return fgsetsort.lattice_bottom, fgsetsort
+
+        @SetIntConstTerm.set_parse_action
+        def interpret_empty_intset(string, loc, tokens):
+            return intsetsort.lattice_bottom, intsetsort
+
+        # TODO: This function is highly specific to its productions. Must be rewritten better if grammar is generalized.
+        @Term.set_parse_action
+        def interpret_term(string, loc, tokens):
+            if len(tokens) == 1:
+                return tokens[0]
+            arg1, binop, arg2 = tokens
+
+            # Check that the arguments are well-typed
+            well_typed = None
+            arg1_old_sort = arg1[1]
+            arg2_old_sort = arg2[1]
+            if binop in {'+', '-', '*'}:
+                well_typed = arg1[1] == arg2[1] and arg1[1] == intsort
+            else:
+                # For set union we can consider individual elements as singletons (only one of the arguments)
+                if binop == '|':
+                    if arg1[1] in {fgsort, intsort}:
+                        arg1_new_sort = sort_to_setsort[arg1[1]]
+                        arg1 = SetAdd(arg1_new_sort.lattice_bottom, arg1[0]), arg1_new_sort
+                    elif arg2[1] in {fgsort, intsort}:
+                        arg2_new_sort = sort_to_setsort[arg2[1]]
+                        arg2 = SetAdd(arg2_new_sort.lattice_bottom, arg2[0]), arg2_new_sort
+                well_typed = arg1[1] == arg2[1] and arg1[1] in {fgsetsort, intsetsort}
+            if not well_typed:
+                raise BadType(f'Cannot operate "{binop}" over operands of type {arg1_old_sort} and {arg2_old_sort}',
+                              loc, string)
+
+            op_lookup = {
+                '&': SetIntersect,
+                '|': SetUnion,
+                '+': lambda x, y: x + y,
+                '-': lambda x, y: x - y,
+                '*': lambda x, y: x * y
+            }
+
+            # The type of the interpretation is the same as the type of its operands in this case
+            return op_lookup[binop](arg1[0], arg2[0]), arg1[1]
+
+        # Grammar for relational atoms
+        # Relation operations used infix. 'in' is set membership and '<', '==', etc are polymorphic.
+        CompOp = pp.one_of("== != < <= > >= in")
+        CompAtom = LParen + Term + CompOp + Term + RParen
+        RelAtom = self.Application.copy()
+        Atom = CompAtom ^ RelAtom
+
+        # Interpretation for relational atoms
+        @CompAtom.set_parse_action
+        def interpret_comparison(string, loc, tokens):
+            (arg1, arg1sort), binop, (arg2, arg2sort) = tokens
+            # Check that the expression is well-typed
+            if binop == 'in':
+                well_typed = arg2sort == sort_to_setsort[arg1sort]
+            else:
+                # Comparisons other than equality/disequality cannot be made on Loc or Bool sort terms
+                well_typed = False if (
+                            binop not in {'==', '!='} and arg1sort in {fgsort, boolsort}) else arg1sort == arg2sort
+            if not well_typed:
+                raise BadType(
+                    f'Cannot interpret {arg1} {binop} {arg2} between arguments of sorts {arg1sort} and {arg2sort}',
+                    loc, string)
+            # Define the conversion from symbols to operators considering the type of the operands
+            if arg2sort == intsort:
+                # Second operand is an integer
+                op_lookup = {
+                    '<': lambda x, y: x < y,
+                    '<=': lambda x, y: x <= y,
+                    '>': lambda x, y: x > y,
+                    '>=': lambda x, y: x >= y
+                }
+            else:
+                # Second operand is a set
+                op_lookup = {
+                    '<': z3.IsSubset,
+                    '<=': lambda x, y: Or(IsSubset(x, y), x == y),
+                    '>': lambda x, y: z3.IsSubset(y, x),
+                    '>=': lambda x, y: Or(IsSubset(y, x), y == x)
+                }
+            op_lookup['in'] = z3.IsMember
+            op_lookup['=='] = lambda x, y: x == y
+            op_lookup['!='] = lambda x, y: x != y
+            return op_lookup[binop](arg1, arg2)
+
+        @RelAtom.add_parse_action
+        def interpret_relation(string, loc, tokens):
+            term, term_sort = tokens[0]
+            if term_sort != boolsort:
+                raise BadType(f'Expected boolean term but found {term} of sort {term_sort}',
+                              loc, string)
+            return term
+
+        # Grammar for boolean combinations
+        UnBoolOp = "!"  # boolean negation
+        BinBoolOp = pp.one_of("& | =>")  # boolean operators used infix
+        Formula <<= Atom ^ (LParen + UnBoolOp + Formula + RParen) ^ (LParen + Formula + BinBoolOp + Formula + RParen)
+
+        # Interpretation for boolean combinations
+        @Formula.set_parse_action
+        def interpret_formula(string, loc, tokens):
+            numtok = len(tokens)
+            if numtok == 1:
+                return tokens
+            elif numtok == 2:
+                # Negation is the only unary operator
+                _, formula = tokens
+                return Not(formula)
+            else:
+                arg1, binop, arg2 = tokens
+                op_lookup = {
+                    '&': And,
+                    '|': Or,
+                    '=>': Implies
+                }
+                return op_lookup[binop](arg1, arg2)

--- a/vcgen/__init__.py
+++ b/vcgen/__init__.py
@@ -1,7 +1,8 @@
 """
-MAIN
-Grammar for programs with annotations:
+% MAIN
+% Grammar for programs with annotations:
 
+% Declarations
 VarName -> alphanumeric
 FuncName -> alphanumeric
 Type -> Loc | Int | SetLoc | SetInt | Bool
@@ -20,9 +21,11 @@ RecDef -> RecFun | RecPred
 RecDefs -> RecDef RecDef ...     % empty set of recdefs allowed if there are no RecFuncDecl statements
 Decls -> FODecls RecDecls
 
+% Annotations
 PreFormula -> @pre: Formula(Application) % see grammar 'COMBINATOR' below
 PostFormula -> @post: Formula(Application) % see grammar 'COMBINATOR' below
 
+% Program statements
 ProgTerm -> VarName | ProgTerm.FuncName % only arity 1 functions can be mutable fields and usable in program terms (no arbitrary uninterpreted functions)
 ProgCond -> Formula(ProgTerm) % see grammar 'COMBINATOR' below
 AssumeStatement -> assume ProgCond
@@ -35,18 +38,20 @@ Input -> Decls PreFormula Program PostFormula
 
 
 """
-COMBINATOR
-Grammar for building terms and formulae from application expressions:
+% COMBINATOR
+% Parametric grammar for building terms and formulae from application expressions:
 % 'Application' is a nonterminal that is a parameter in this grammar
 
 IntConst -> signed_integers
 SetConst -> empSetLoc | empSetInt
-TermAtom -> IntConst | SetConst | Application
+BoolConst -> True | False
+TermAtom -> IntConst | SetConst | BoolConst | Application
 BinTermOp -> + | - | * |     % integer operations
              &         |     % set intersection
              |               % set union/ set addition
 Term -> TermAtom             |
         (Term BinTermOp Term)
+        (If Formula Then Term Else Term)
 
 % comparison operators are polymorphic
 % 'in' denotes set membership
@@ -54,8 +59,9 @@ CompOp -> == | != | < | <= | > | >= | in
 Atom -> Application       |
         (Term CompOp Term)
 Formula -> Atom
-           (Formula & Formula)  |
-           (Formula | Formula)  |
-           (Formula => Formula) |
+           (Formula & Formula)                    |
+           (Formula | Formula)                    |
+           (Formula => Formula)                   |
+           (If Formula Then Formula Else Formula) |
            (! Formula)
 """

--- a/vcgen/__init__.py
+++ b/vcgen/__init__.py
@@ -1,0 +1,61 @@
+"""
+MAIN
+Grammar for programs with annotations:
+
+VarName -> alphanumeric
+FuncName -> alphanumeric
+Type -> Loc | Int | SetLoc | SetInt | Bool
+
+VarDecl -> Var VarName Type
+FuncDecl -> Function FuncName Type Type ...
+RecFuncDecl -> RecFunction FuncName Type Type ...
+FODecl -> VarDecl | FuncDecl | RecFuncDecl
+FODecls -> FODecl FODecl ...     % empty set of fields not allowed
+Application -> VarName                               |
+               Function(Application, Application ...)  % empty set of arguments not allowed
+
+RecFun -> Def FuncName(VarName, VarName, ... VarName) := Term(Application) % see grammar 'COMBINATOR' below
+RecPred -> Def FuncName(VarName, VarName, ... VarName) := Formula(Application) % see grammar 'COMBINATOR' below
+RecDef -> RecFun | RecPred
+RecDefs -> RecDef RecDef ...     % empty set of recdefs allowed if there are no RecFuncDecl statements
+Decls -> FODecls RecDecls
+
+PreFormula -> @pre: Formula(Application) % see grammar 'COMBINATOR' below
+PostFormula -> @post: Formula(Application) % see grammar 'COMBINATOR' below
+
+ProgTerm -> VarName | ProgTerm.FuncName % only arity 1 functions can be mutable fields and usable in program terms (no arbitrary uninterpreted functions)
+ProgCond -> Formula(ProgTerm) % see grammar 'COMBINATOR' below
+AssumeStatement -> assume ProgCond
+AssignOrMutateStatement -> ProgTerm := ProgTerm
+Statement -> AssumeStatement | AssignOrMutateStatement
+Program -> Statement Statement ...
+
+Input -> Decls PreFormula Program PostFormula
+"""
+
+
+"""
+COMBINATOR
+Grammar for building terms and formulae from application expressions:
+% 'Application' is a nonterminal that is a parameter in this grammar
+
+IntConst -> signed_integers
+SetConst -> empSetLoc | empSetInt
+TermAtom -> IntConst | SetConst | Application
+BinTermOp -> + | - | * |     % integer operations
+             &         |     % set intersection
+             |               % set union/ set addition
+Term -> TermAtom             |
+        (Term BinTermOp Term)
+
+% comparison operators are polymorphic
+% 'in' denotes set membership
+CompOp -> == | != | < | <= | > | >= | in
+Atom -> Application       |
+        (Term CompOp Term)
+Formula -> Atom
+           (Formula & Formula)  |
+           (Formula | Formula)  |
+           (Formula => Formula) |
+           (! Formula)
+"""

--- a/vcgen/parser.py
+++ b/vcgen/parser.py
@@ -1,0 +1,301 @@
+import z3
+import pyparsing as pp
+
+from naturalproofs.uct import fgsort, fgsetsort, intsort, intsetsort, boolsort
+from naturalproofs.decl_api import Var, Function, RecFunction, AddRecDefinition
+
+from vcgen.utils import LParen, RParen
+from vcgen.utils import RedeclarationException, UnknownExpression
+from vcgen.utils import InterpretationException, BadType, BadDefinitionException
+from vcgen.utils import ProgramState
+
+from vcgen.CombinatorLogic import CombinatorLogic
+
+
+# Keywords and other important symbols
+# Some are suppressed since they are purely for better aesthetic of input. Some are not suppressed since they will be
+# used to make decisions during the parsing
+VariableDeclarationTag = pp.Literal("Var").suppress()
+FunctionDeclarationTag = pp.Literal("Function")
+RecFunctionDeclaractionTag = pp.Literal("RecFunction")
+RecFunctionDefinitionTag = pp.Literal("Def").suppress()
+PreconditionTag = pp.Literal("@pre:")
+PostconditionTag = pp.Literal("@post:")
+AssignmentOperator = pp.Literal(":=").suppress()
+Dot = pp.Literal(".").suppress()
+AssumeStatementTag = pp.Literal("assume").suppress()
+
+
+#### Phase 1: declarations and recursive definitions
+# Data structures for representing program state
+# vardict is a dictionary from variable names as strings to information about the variable. The info tracked is
+# the type of the variable and its current value as a z3.ExprRef as well as a counter storing the number of copies
+vardict = dict()
+# funcdict is a dictionary from function names as strings to info about the function. The components have
+# the same meaning as in vardict. The current value component may be a python function
+# that produces an expression equivalent to the function lookup at that point in the program (for mutable functions).
+funcdict = dict()
+# recdefdict is a dictionary from the names of recursive definitions as strings to info about them
+# The information tracked is their bodies and formal parameters as strings
+# The bodies are maintained as strings since we will only be able to compute the meaning of the body given other info
+# about the program state such as the FO functions.
+recdefdict = dict()
+
+
+# Defining a grammar for types, variables, and functions
+# Grammar for basic symbols
+Type = pp.one_of("Loc SetLoc Int SetInt Bool")
+VarName = pp.Word(pp.alphanums)
+FuncName = pp.Word(pp.alphanums)
+
+
+# Interpretation of types
+@Type.set_parse_action
+def translate_type(string, loc, tokens):
+    annotation = tokens[0]
+    type_lookup = {
+        'Loc': fgsort,
+        'SetLoc': fgsetsort,
+        'Int': intsort,
+        'SetInt': intsetsort,
+        'Bool': boolsort
+    }
+    return type_lookup[annotation]
+
+
+# Grammar for declarations
+VarDecl = VariableDeclarationTag + VarName + Type
+FuncDecl = (FunctionDeclarationTag ^ RecFunctionDeclaractionTag) + FuncName + Type[2, ...]
+FODecl = pp.Group(VarDecl ^ FuncDecl)
+
+
+# Interpretation for declarations
+@VarDecl.set_parse_action
+def store_variable(string, loc, tokens):
+    var_name, var_type = tokens
+    _ = vardict.get(var_name, None)
+    if _ is not None:
+        raise RedeclarationException(f'Variable {var_name} is redeclared', loc, string)
+    info_dict = {'type': var_type, 'value': Var(var_name, var_type), 'counter': 1}
+    vardict[var_name] = info_dict
+
+
+@FuncDecl.set_parse_action
+def store_field(string, loc, tokens):
+    func_tag, func_name, func_type = tokens[0], tokens[1], tokens[2:]
+    _ = funcdict.get(func_name, None)
+    if _ is not None:
+        raise RedeclarationException(f'Function {func_name} is redeclared', loc, string)
+    # Create temporary non-api objects for recfunctions
+    info_dict = {'type': func_type,
+                 'value': z3.Function(func_name, *func_type) if func_tag == 'RecFunction' else Function(func_name, *func_type)}
+    funcdict[func_name] = info_dict
+    if func_tag == 'RecFunction':
+        recdefdict[func_name] = dict()
+
+
+# Grammar for variables and functions
+Variable = pp.Word(pp.alphanums)
+FOFunction = pp.Word(pp.alphanums)
+
+
+# Interpretation for variables
+@Variable.set_parse_action
+def interpret_variable(string, loc, tokens):
+    var_name = tokens[0]
+    var = vardict.get(var_name, None)
+    if var is None:
+        raise InterpretationException(f'Unknown variable {var_name}', loc, string)
+    interp, sort = vardict[var_name]['value'], vardict[var_name]['type']
+    return interp, sort
+
+
+# Grammar for application terms
+Application = pp.Forward()
+Application <<= Variable ^ (pp.Combine(FOFunction + LParen) + pp.delimitedList(Application) + RParen)
+
+
+# Interpretation for application terms
+# A term is interpreted as a z3.ExprRef. The interpretation functions below return both the interpretation and the
+# uct sort to be used when parsing formulas.
+@Application.set_parse_action
+def interpret_application(string, loc, tokens):
+    if len(tokens) == 1:
+        return tokens[0]
+    else:
+        func_name, args = tokens[0], tokens[1:]
+        # Lookup function in program state
+        if func_name in funcdict:
+            func = funcdict[func_name]['value']
+        else:
+            raise InterpretationException(f'Unknown function {func_name}', loc, string)
+        # Check that the term is well-typed
+        func_signature = funcdict['type']
+        expected_sorts = func_signature[:-1]
+        obtained_sorts = [arg[1] for arg in args]
+        if len(expected_sorts) != len(obtained_sorts):
+            raise BadType(f'Wrong number of arguments to {func_name}: expected {len(expected_sorts)} but '
+                          f'obtained {len(obtained_sorts)}', loc, string)
+        try:
+            mismatch = next(i for i in range(len(expected_sorts)) if expected_sorts[i] != obtained_sorts[i])
+            raise BadType(f'Wrong argument type for argument number {mismatch + 1} of {func_name}: '
+                          f'expected {expected_sorts[mismatch]} but obtained {obtained_sorts[mismatch]}',
+                          loc, string)
+        except StopIteration:
+            pass
+        interp = func(*[arg[0] for arg in args])
+        return interp, func_signature[-1]
+
+
+# Grammar for annotations and other formulas. Recdef bodies will be defined using the same language.
+# The term/formula language is induced over the application language defined above.
+annotation_logic = CombinatorLogic(Application)
+AnnotationTerm = annotation_logic.Term
+AnnotationFormula = annotation_logic.Formula
+# Term/Formula language that does not parse into an expression. This is useful because we just want to store
+# the bodies of recursive definitions as strings until we need to instantiate them at a particular program state.
+# However, the parsing will internally still finish the transformation into an expression
+# and can therefore catch errors.
+BareAnnotationTerm = pp.original_text_for(AnnotationTerm)
+BareAnnotationFormula = pp.original_text_for(AnnotationFormula)
+# Grammar for recursive definitions
+RecDef = RecFunctionDefinitionTag + (pp.Combine(FuncName + LParen) + pp.Group(pp.delimitedList(VarName)) + RParen) \
+         + AssignmentOperator + (BareAnnotationTerm ^ BareAnnotationFormula)
+
+
+# Interpretation for recursive definitions
+@RecDef.set_parse_action
+def store_rec_decl(string, loc, tokens):
+    def_name, formal_params, body = tokens
+    # Check that the function has been declared
+    recdef_info = recdefdict.get(def_name, None)
+    if recdef_info is None:
+        raise BadDefinitionException(f'Symbol {def_name} undeclared', loc, string)
+    elif recdef_info != dict():
+        raise BadDefinitionException(f'Two definitions for {def_name}', loc, string)
+    # Check if the definition is well-formed (best effort)
+    given_arity = len(formal_params)
+    expected_arity = len(funcdict[def_name]['type']) - 1
+    if given_arity != expected_arity:
+        raise BadDefinitionException(f'Arity mismatch: {def_name} has arity {expected_arity} '
+                                     f'but was given {given_arity} arguments', loc, string)
+    recdefdict[def_name] = {'params': list(formal_params), 'body': body}
+
+
+# Grammar for all predeclarations
+# Terminate the declarations with an empty token so we can check whether the logic is sufficiently defined
+StopDecls = pp.Empty()
+Decls = FODecl[1, ...] + RecDef[...] + StopDecls
+
+
+# Checking that the declarations have been made correctly.
+@StopDecls.add_condition
+def check_decls(string, loc, tokens):
+    # Check whether every function declared as a recfunction has a definition
+    no_body = [def_name for def_name, value in recdefdict.items() if value == dict()]
+    if not no_body:
+        raise BadDefinitionException(f'The following were declared as recursive functions '
+                                     f'but no definition was given: {", ".join(no_body)}')
+    # Check whether footprint functions are defined for every normal recursive definition
+    basic_defs = [recdef for recdef in recdefdict if not recdef.startswith('SP')]
+    for recdef in basic_defs:
+        if 'SP' + recdef not in recdefdict:
+            raise BadDefinitionException(f'Footprint definition {"SP" + recdef} not found for definition {recdef}')
+    return True
+
+
+#### Phase 2: precondition, program, and postcondition
+# This part of the input is separated from the previous part by the empty token StopDecls
+# Datastructures to track parsing progress: precondition, program transformation formula, footprint, and postcondition
+pre_state = None
+pre_cond = None
+trans = []
+footprint = []
+post_state = None
+post_cond = None
+
+
+# Grammar for pre and post conditions
+StateMarker = PreconditionTag ^ PostconditionTag
+Annotation = StateMarker + AnnotationFormula
+
+
+# Interpretation for pre and post conditions
+# Function to make a well-defined program state
+# This involves adding definitions for recursive functions using the value of the mutable functions at that state.
+@StateMarker.set_parse_action
+def instantiate_prog_state(string, loc, tokens):
+    state_name = tokens[0][1:-1]
+    for def_name in recdefdict:
+        # Declare the functions
+        funcdict[def_name]['value'] = RecFunction(f'{def_name}@{state_name}', *funcdict[def_name]['type'])
+        # Define the body expression
+        formal_params = [Var(f'{recdefdict[def_name]["params"][i]}@{state_name}', funcdict[def_name]['type'][i])
+                         for i in range(len(recdefdict[def_name]['params']))]
+        body_string = recdefdict[def_name]['body']
+        parser_element = AnnotationFormula if funcdict[def_name]['type'][-1] == boolsort else AnnotationTerm
+        body = parser_element.parse_string(body_string)
+        AddRecDefinition(funcdict[def_name]['value'], formal_params, body)
+    # Construct state
+    prog_state = ProgramState(vardict, funcdict, state_name)
+    if state_name == 'pre':
+        global pre_state
+        pre_state = prog_state
+    elif state_name == 'post':
+        global post_state
+        post_state = prog_state
+
+
+# When parsing this the StateMarker action will have already been executed, therefore formulae will be interpreted
+# in the correct program state. This relies on knowledge of the order in which pyparsing executes the actions of
+# sequentially ordered nonterminals.
+@Annotation.set_parse_action
+def store_annotation(string, loc, tokens):
+    state_marker, annotation_formula = tokens
+    state_name = state_marker[1:-1]
+    if state_name == 'pre':
+        global pre_cond
+        pre_cond = annotation_formula
+    elif state_name == 'post':
+        global post_cond
+        post_cond = annotation_formula
+
+
+# Grammar for program terms and conditions
+ProgTerm = pp.Forward()
+ProgTerm <<= Variable ^ (pp.Combine(ProgTerm + Dot + FOFunction))
+# The condition language is induced over the program term language defined above.
+prog_cond = CombinatorLogic(ProgTerm)
+ProgCond = prog_cond.Formula
+
+
+# Interpretation of program terms
+@ProgTerm.set_parse_action
+def interpret_prog_term(string, loc, tokens):
+    if len(tokens) == 1:
+        return tokens[0]
+    (subterm, subterm_sort), func_name = tokens
+    # Check that the expression is well-typed
+    func_info = funcdict.get(func_name, None)
+    if func_info is None:
+        raise UnknownExpression(f'Unknown function {func_name}', loc, string)
+    expected_sort = func_info['type'][:-1]
+    if tuple(subterm_sort) != expected_sort:
+        raise UnknownExpression(f'Cannot apply {func_name} of type {expected_sort} '
+                                f'to argument of type {subterm_sort}', loc, string)
+    interp = func_info['value'](subterm)
+    interp_sort = func_info['type'][-1]
+    return interp, interp_sort
+
+
+# Grammar for program statements
+AssumeStatement = AssumeStatementTag + ProgCond
+AssignOrMutateStatement = ProgTerm + AssignmentOperator + ProgTerm
+Statement = AssumeStatement ^ AssignOrMutateStatement
+Statements = Statement[...]
+
+
+# Interpretation for program statements
+# TODO
+
+

--- a/vcgen/parser.py
+++ b/vcgen/parser.py
@@ -266,17 +266,18 @@ def store_annotation(string, loc, tokens):
 
 
 # Grammar for program terms and conditions
-# ProgTerm = pp.Forward()
-# ProgTerm <<= Variable ^ (pp.Combine(ProgTerm + Dot + FOFunction))
-# Program term has to be defined in this weird way because pyparsing has trouble with left recursion
-ProgTerm = Variable + (Dot + FOFunction)[...]
+# ProgApplication = pp.Forward()
+# ProgApplication <<= Variable ^ (pp.Combine(ProgApplication + Dot + FOFunction))
+# Program applications have to be defined in this weird way because pyparsing has trouble with left recursion
+ProgApplication = Variable + (Dot + FOFunction)[...]
 # The condition language is induced over the program term language defined above.
-prog_cond = CombinatorLogic(ProgTerm)
-ProgCond = prog_cond.Formula
+prog_logic = CombinatorLogic(ProgApplication)
+ProgTerm = prog_logic.Term
+ProgCond = prog_logic.Formula
 
 
-# Interpretation of program terms
-@ProgTerm.set_parse_action
+# Interpretation of program application expressions
+@ProgApplication.set_parse_action
 def interpret_prog_term(string, loc, tokens):
     if len(tokens) == 1:
         return tokens[0]
@@ -298,7 +299,7 @@ def interpret_prog_term(string, loc, tokens):
 
 # Grammar for program statements
 AssumeStatement = AssumeStatementTag + ProgCond
-AssignOrMutateStatement = ProgTerm + AssignmentOperator + ProgTerm
+AssignOrMutateStatement = ProgApplication + AssignmentOperator + ProgTerm
 Statement = AssumeStatement ^ AssignOrMutateStatement
 Statements = Statement[...]
 

--- a/vcgen/parser.py
+++ b/vcgen/parser.py
@@ -322,3 +322,5 @@ Statements = Statement[...]
 
 
 Program = Decls + Annotation + Statements + Annotation
+# Add single and multiline comments (c++ style)
+Program = Program.ignore(pp.cpp_style_comment)

--- a/vcgen/tests.py
+++ b/vcgen/tests.py
@@ -5,33 +5,44 @@ from vcgen.parser import vardict, funcdict, recdefdict
 
 
 ProgramText = pp.original_text_for(Program)
-pgm = """
-Var x Loc
-Var y Loc
-Var nil Loc
-Function next Loc Loc
-Function prev Loc Loc
-RecFunction list Loc Bool
-RecFunction SPlist Loc SetLoc
-RecFunction dlist Loc Bool
-RecFunction SPdlist Loc SetLoc
 
-Def list(x) := ((x == nil) | ((x != nil) & list(next(x))))
-Def SPlist(x) := (If (x == nil) Then empSetLoc Else (x | SPlist(next(x))))
+# pgm = """
+# Var x Loc
+# Var y Loc
+# Var nil Loc
+# Function next Loc Loc
+# Function prev Loc Loc
+# RecFunction list Loc Bool
+# RecFunction SPlist Loc SetLoc
+# RecFunction dlist Loc Bool
+# RecFunction SPdlist Loc SetLoc
+#
+# Def list(x) := (If (x == nil) Then True Else list(next(x)))
+# Def SPlist(x) := (If (x == nil) Then empSetLoc Else (x | SPlist(next(x))))
+#
+# Def dlist(x) := (If (x == nil) Then True Else ((next(prev(x)) == x) & dlist(next(x))))
+# Def SPdlist(x) := (If (x == nil) Then empSetLoc Else (x | SPdlist(next(x))))
+#
+# @pre: dlist(x)
+# assume (x != nil)
+# assume (x.next != nil)
+# x.next.next := x.next
+# @post: list(x)
+# """
+#
+# for parse_elem in ProgramText.parse_string(pgm):
+#     print(parse_elem)
+#
+# # These represent states of the program at the end of parsing. Not correct yet since
+# # actions have not been implemented for program statements
+# print(vardict)
+# print(funcdict)
+# print(recdefdict)
 
-Def dlist(x) := ((x == nil) | ((x != nil) & ((next(prev(x)) == x) & dlist(next(x)))))
-Def SPdlist(x) := (If (x == nil) Then empSetLoc Else (x | SPdlist(next(x))))
 
-@pre: dlist(x)
-assume (x != nil)
-assume (x.next != nil)
-x.next.next := x.next
-@post: list(x)
-"""
-
-for parse_elem in ProgramText.parse_string(pgm):
+# Use this command to read from a file instead
+filename = 'tests/example.fsl'
+for parse_elem in ProgramText.parse_file(filename):
     print(parse_elem)
 
-print(vardict)
-print(funcdict)
-print(recdefdict)
+print('\nParsing Successful!\n')

--- a/vcgen/tests.py
+++ b/vcgen/tests.py
@@ -1,0 +1,37 @@
+import pyparsing as pp
+
+from vcgen.parser import Program
+from vcgen.parser import vardict, funcdict, recdefdict
+
+
+ProgramText = pp.original_text_for(Program)
+pgm = """
+Var x Loc
+Var y Loc
+Var nil Loc
+Function next Loc Loc
+Function prev Loc Loc
+RecFunction list Loc Bool
+RecFunction SPlist Loc SetLoc
+RecFunction dlist Loc Bool
+RecFunction SPdlist Loc SetLoc
+
+Def list(x) := ((x == nil) | ((x != nil) & list(next(x))))
+Def SPlist(x) := (If (x == nil) Then empSetLoc Else (x | SPlist(next(x))))
+
+Def dlist(x) := ((x == nil) | ((x != nil) & ((next(prev(x)) == x) & dlist(next(x)))))
+Def SPdlist(x) := (If (x == nil) Then empSetLoc Else (x | SPdlist(next(x))))
+
+@pre: dlist(x)
+assume (x != nil)
+assume (x.next != nil)
+x.next.next := x.next
+@post: list(x)
+"""
+
+for parse_elem in ProgramText.parse_string(pgm):
+    print(parse_elem)
+
+print(vardict)
+print(funcdict)
+print(recdefdict)

--- a/vcgen/tests.py
+++ b/vcgen/tests.py
@@ -6,10 +6,27 @@ from vcgen.parser import vardict, funcdict, recdefdict
 
 ProgramText = pp.original_text_for(Program)
 
+# Use this command to read the input from a file
+filename = 'tests/example.fsl'
+for parse_elem in ProgramText.parse_file(filename):
+    print(parse_elem)
+
+print('\nParsing Successful!\n')
+
+
+# You can also make a string within python and use parse_string instead of parse_file
 # pgm = """
+# // General format of the input: Declarations, followed by recursive definitions, followed by pre, program, and post.
+# // This is how you write single line comments
+# /* This is how you write
+#  multiline comments */
+#
 # Var x Loc
 # Var y Loc
-# Var nil Loc
+# // This is how you declare constants. Be sure to distinguish them during declaration by using 'Const'.
+# Const nil Loc
+#
+# // You should distinguish normal functions and recursive functions in the syntax
 # Function next Loc Loc
 # Function prev Loc Loc
 # RecFunction list Loc Bool
@@ -17,16 +34,24 @@ ProgramText = pp.original_text_for(Program)
 # RecFunction dlist Loc Bool
 # RecFunction SPdlist Loc SetLoc
 #
+# /* Recursive definitions must always be defined with supports.
+# The support of a recursive function <name> is of the form SP<name>.
+# The creation of these support functions is not automatic yet. */
+#
 # Def list(x) := (If (x == nil) Then True Else list(next(x)))
 # Def SPlist(x) := (If (x == nil) Then empSetLoc Else (x | SPlist(next(x))))
 #
 # Def dlist(x) := (If (x == nil) Then True Else ((next(prev(x)) == x) & dlist(next(x))))
 # Def SPdlist(x) := (If (x == nil) Then empSetLoc Else (x | SPdlist(next(x))))
 #
+# // Only one precondition or postcondition can be defined at the moment.
 # @pre: dlist(x)
+#
+# // There are only two kinds of statements: assume statements and assignment statements
 # assume (x != nil)
 # assume (x.next != nil)
 # x.next.next := x.next
+#
 # @post: list(x)
 # """
 #
@@ -38,11 +63,3 @@ ProgramText = pp.original_text_for(Program)
 # print(vardict)
 # print(funcdict)
 # print(recdefdict)
-
-
-# Use this command to read from a file instead
-filename = 'tests/example.fsl'
-for parse_elem in ProgramText.parse_file(filename):
-    print(parse_elem)
-
-print('\nParsing Successful!\n')

--- a/vcgen/tests/example.fsl
+++ b/vcgen/tests/example.fsl
@@ -1,0 +1,21 @@
+Var x Loc
+Var y Loc
+Var nil Loc
+Function next Loc Loc
+Function prev Loc Loc
+RecFunction list Loc Bool
+RecFunction SPlist Loc SetLoc
+RecFunction dlist Loc Bool
+RecFunction SPdlist Loc SetLoc
+
+Def list(x) := (If (x == nil) Then True Else list(next(x)))
+Def SPlist(x) := (If (x == nil) Then empSetLoc Else (x | SPlist(next(x))))
+
+Def dlist(x) := (If (x == nil) Then True Else ((next(prev(x)) == x) & dlist(next(x))))
+Def SPdlist(x) := (If (x == nil) Then empSetLoc Else (x | SPdlist(next(x))))
+
+@pre: dlist(x)
+assume (x != nil)
+assume (x.next != nil)
+x.next.next := x.next
+@post: list(x)

--- a/vcgen/tests/example.fsl
+++ b/vcgen/tests/example.fsl
@@ -1,6 +1,14 @@
+// General format of the input: Declarations, followed by recursive definitions, followed by pre, program, and post.
+// This is how you write single line comments
+/* This is how you write
+ multiline comments */
+
 Var x Loc
 Var y Loc
-Var nil Loc
+// This is how you declare constants. Be sure to distinguish them during declaration by using 'Const'.
+Const nil Loc
+
+// You should distinguish normal functions and recursive functions in the syntax
 Function next Loc Loc
 Function prev Loc Loc
 RecFunction list Loc Bool
@@ -8,14 +16,22 @@ RecFunction SPlist Loc SetLoc
 RecFunction dlist Loc Bool
 RecFunction SPdlist Loc SetLoc
 
+/* Recursive definitions must always be defined with supports.
+The support of a recursive function <name> is of the form SP<name>.
+The creation of these support functions is not automatic yet. */
+
 Def list(x) := (If (x == nil) Then True Else list(next(x)))
 Def SPlist(x) := (If (x == nil) Then empSetLoc Else (x | SPlist(next(x))))
 
 Def dlist(x) := (If (x == nil) Then True Else ((next(prev(x)) == x) & dlist(next(x))))
 Def SPdlist(x) := (If (x == nil) Then empSetLoc Else (x | SPdlist(next(x))))
 
+// Only one precondition or postcondition can be defined at the moment.
 @pre: dlist(x)
+
+// There are only two kinds of statements: assume statements and assignment statements
 assume (x != nil)
 assume (x.next != nil)
 x.next.next := x.next
+
 @post: list(x)

--- a/vcgen/utils.py
+++ b/vcgen/utils.py
@@ -1,0 +1,95 @@
+"""
+This module defines some general functions, classes, and constants used by several parsing modules.
+"""
+
+import pyparsing as pp
+
+from naturalproofs.uct import fgsort, fgsetsort, intsort, intsetsort
+
+
+# Dictionary to convert from a sort to its corresponding set sort
+sort_to_setsort = {fgsort: fgsetsort, intsort: intsetsort}
+# Special tokens
+LParen = pp.Literal("(").suppress()
+RParen = pp.Literal(")").suppress()
+
+
+# decorator to suppress actions depending on a boolean value
+def suppress_parse_action(parser_element, dry):
+    def wrapper(func):
+        if dry:
+            parser_element.set_parse_action(None)
+        return func
+    return wrapper
+
+
+# Class to capture program state
+class ProgramState:
+    """
+    This class is initialized by a set of dictionaries that represent a program state. It is used to freeze the
+    program state at a particular point to use later.
+    """
+    def __init__(self, vardict, funcdict, name=None):
+        # Data structures for representing program state
+        # vardict is a dictionary from variable names as strings to information about the variable. The info present is
+        # the type of the variable and its current value as a z3.ExprRef.
+        self.vardict = vardict
+        # funcdict is a dictionary from data/pointer field names as strings to info about the fields. The components have
+        # the same meaning as in vardict. The current value component will sometimes be a python function
+        # that produces an expression equivalent to the field lookup at that point in the program.
+        self.funcdict = funcdict
+        # Name of the state
+        self.name = name
+
+
+# Exception master class
+class FOSSILParserException(Exception):
+    """
+    This exception class defines some general utilities that many specific parsing exception classes will use.
+    """
+    def __init__(self, message="", loc=None, string=None):
+        if loc is not None and string is not None:
+            # Find the line and column number corresponding to the given location in the string
+            linecol = f'{pp.lineno(loc, string)}:{pp.col(loc, string)}'
+            self.message = f'{message} at {linecol}'
+        else:
+            self.message = message
+
+    def __str__(self):
+        return self.message
+
+
+# Exception classes
+class InterpretationException(FOSSILParserException):
+    """
+    This exception is raised when a term or formula cannot be interpreted in the current program state.
+    """
+    pass
+
+
+class BadType(FOSSILParserException):
+    """
+    This exception is raised when attempting to parse an ill-typed formula.
+    """
+    pass
+
+
+class RedeclarationException(FOSSILParserException):
+    """
+    This exception is raised when a variable, field, or recursive definition is given two declarations.
+    """
+    pass
+
+
+class BadDefinitionException(FOSSILParserException):
+    """
+    This exception is raised when a function definition cannot be reconciled with its declaration.
+    """
+    pass
+
+
+class UnknownExpression(FOSSILParserException):
+    """
+    This exception is raised when an expression in the program cannot be interpreted.
+    """
+    pass


### PR DESCRIPTION
This PR represents the first step towards creating a programming language interface that can generate VCs in FO+lfp which are then subsequently handled by natural proofs and/or lemma synthesis. The annotations can either be in Frame Logic or FO+lfp. 

At the time of this PR the input language is fairly stable (vcgen/__init__.py), but the VC generation itself is yet to be done. All changes to the codebase are contained to the vcgen/ subdirectory.